### PR TITLE
First round of Linux 64-bit fixes.

### DIFF
--- a/Engine/src/draw.c
+++ b/Engine/src/draw.c
@@ -36,7 +36,7 @@ static int transrev = 0;
 
 /* ---------------  WALLS RENDERING METHOD (USED TO BE HIGHLY OPTIMIZED ASSEMBLY) ----------------------------*/
 extern int32_t asm1;
-extern int32_t asm2;
+extern intptr_t asm2;
 extern uint8_t *asm3;
 extern int32_t asm4;
 
@@ -312,8 +312,8 @@ void tvlineasm2(uint32_t i1, uint32_t i2, uintptr_t i3, uintptr_t i4, uint32_t i
 	uint32_t tran2incb = asm1;
 	uintptr_t tran2bufa = i3;
 	uintptr_t tran2bufb = i4;
-	uint32_t tran2edi = asm2;
-	uint32_t tran2edi1 = asm2 + 1;
+	uintptr_t tran2edi = asm2;
+	uintptr_t tran2edi1 = asm2 + 1;
 
 	i6 -= asm2;
 

--- a/Engine/src/draw.c
+++ b/Engine/src/draw.c
@@ -152,7 +152,7 @@ void setuprmhlineasm4(int32_t i1, int32_t i2, int32_t i3, int32_t i4, int32_t ti
 
 
 //FCS: ????
-void rmhlineasm4(int32_t i1, int32_t shade, int32_t colorIndex, int32_t i4, int32_t i5, int32_t dest)
+void rmhlineasm4(int32_t i1, intptr_t shade, int32_t colorIndex, int32_t i4, int32_t i5, int32_t dest)
 {
     uint32_t ebp = dest - i1;
     uint32_t rmach6b = ebp-1;
@@ -305,13 +305,13 @@ void setuptvlineasm2(int32_t i1, int32_t i2, int32_t i3)
 } /* */
 
 
-void tvlineasm2(uint32_t i1, uint32_t i2, uint32_t i3, uint32_t i4, uint32_t i5, uint32_t i6)
+void tvlineasm2(uint32_t i1, uint32_t i2, uintptr_t i3, uintptr_t i4, uint32_t i5, uintptr_t i6)
 {
 	uint32_t ebp = i1;
 	uint32_t tran2inca = i2;
 	uint32_t tran2incb = asm1;
-	uint32_t tran2bufa = i3;
-	uint32_t tran2bufb = i4;
+	uintptr_t tran2bufa = i3;
+	uintptr_t tran2bufb = i4;
 	uint32_t tran2edi = asm2;
 	uint32_t tran2edi1 = asm2 + 1;
 
@@ -400,7 +400,7 @@ void setupvlineasm(int32_t i1)
 }
 
 //FCS This is used to fill the inside of a wall (so it draws VERTICAL column, always).
-void vlineasm4(int32_t columnIndex, int32_t framebuffer)
+void vlineasm4(int32_t columnIndex, intptr_t framebuffer)
 {
 
 	if (!RENDER_DRAW_WALL_INSIDE)
@@ -410,7 +410,7 @@ void vlineasm4(int32_t columnIndex, int32_t framebuffer)
         int i;
         uint32_t temp;
         
-        uint32_t index = (framebuffer + ylookup[columnIndex]);
+        uintptr_t index = (framebuffer + ylookup[columnIndex]);
         uint8_t  *dest= (uint8_t *)(-ylookup[columnIndex]);
         //uint8_t  *dest= (uint8_t *)framebuffer;
         
@@ -440,11 +440,11 @@ void setupmvlineasm(int32_t i1)
 } 
 
 
-void mvlineasm4(int32_t column, int32_t framebufferOffset)
+void mvlineasm4(int32_t column, intptr_t framebufferOffset)
 {
     int i;
     uint32_t temp;
-    uint32_t index = (framebufferOffset + ylookup[column]);
+    uintptr_t index = (framebufferOffset + ylookup[column]);
     uint8_t  *dest = (uint8_t *)(-ylookup[column]);
 
     do {
@@ -821,14 +821,14 @@ void tsethlineshift(int32_t i1, int32_t i2)
 
 
 
-static int32_t slopemach_ebx;
+static intptr_t slopemach_ebx;
 static int32_t slopemach_ecx;
 static int32_t slopemach_edx;
 static uint8_t  slopemach_ah1;
 static uint8_t  slopemach_ah2;
 static float asm2_f;
 typedef union { unsigned int i; float f; } bitwisef2i;
-void setupslopevlin(int32_t i1, int32_t i2, int32_t i3)
+void setupslopevlin(int32_t i1, intptr_t i2, int32_t i3)
 {
     bitwisef2i c;
     slopemach_ebx = i2;
@@ -848,7 +848,7 @@ extern int32_t fpuasm;
 #define high32(a) ((int)(((__int64)a&(__int64)0xffffffff00000000)>>32))
 
 //FCS: Render RENDER_SLOPPED_CEILING_AND_FLOOR
-void slopevlin(int32_t i1, uint32_t i2, int32_t i3, int32_t i4, int32_t i5, int32_t i6)
+void slopevlin(intptr_t i1, uint32_t i2, int32_t i3, int32_t i4, int32_t i5, int32_t i6)
 {
     bitwisef2i c;
     uint32_t ecx,eax,ebx,edx,esi,edi;

--- a/Engine/src/draw.h
+++ b/Engine/src/draw.h
@@ -27,7 +27,7 @@ extern uint8_t  *transluc;
 extern uint8_t  *globalpalwritten;
 extern int16_t  globalshiftval;
 extern int32_t vplce[4], vince[4];
-extern int32_t bufplce[4];
+extern intptr_t bufplce[4];
 extern uint8_t* palookupoffse[4];
         
 void sethlinesizes(int32_t,int32_t,uint8_t *);
@@ -37,7 +37,7 @@ void hlineasm4(int32_t,int32_t,uint32_t,uint32_t,uint8_t*);
 void setuprhlineasm4(int32_t,int32_t,int32_t,int32_t,int32_t,int32_t);
 void rhlineasm4(int32_t,uint8_t*,int32_t,uint32_t,uint32_t,int32_t);
 void setuprmhlineasm4(int32_t,int32_t,int32_t,int32_t,int32_t,int32_t);
-void rmhlineasm4(int32_t,int32_t,int32_t,int32_t,int32_t,int32_t);
+void rmhlineasm4(int32_t,intptr_t,int32_t,int32_t,int32_t,int32_t);
 
 
 void setBytesPerLine(int32_t);
@@ -47,12 +47,12 @@ int32_t vlineasm1(int32_t,uint8_t*,int32_t,int32_t,uint8_t  *,uint8_t*);
 
 int32_t tvlineasm1(int32_t,uint8_t  *,int32_t,int32_t,uint8_t  *,uint8_t  * dest);
 void setuptvlineasm2(int32_t,int32_t,int32_t);
-void tvlineasm2(uint32_t,uint32_t,uint32_t,uint32_t,uint32_t,uint32_t);
+void tvlineasm2(uint32_t,uint32_t,uintptr_t,uintptr_t,uint32_t,uintptr_t);
 int32_t mvlineasm1(int32_t,uint8_t*,int32_t,int32_t,uint8_t* texture,uint8_t* dest);
 void setupvlineasm(int32_t);
-void vlineasm4(int32_t,int32_t);
+void vlineasm4(int32_t,intptr_t);
 void setupmvlineasm(int32_t);
-void mvlineasm4(int32_t,int32_t);
+void mvlineasm4(int32_t,intptr_t);
 void setupspritevline(int32_t,int32_t,int32_t,int32_t,int32_t,int32_t);
 void spritevline(int32_t,uint32_t,int32_t,uint32_t,uint8_t*,uint8_t*);
 void msetupspritevline(int32_t,int32_t,int32_t,int32_t,int32_t,int32_t);
@@ -65,8 +65,8 @@ void msethlineshift(int32_t,int32_t);
 void thline(uint8_t*,int32_t,int32_t,int32_t,int32_t,uint8_t *);
 void thlineskipmodify(int32_t,uint32_t,uint32_t,int32_t,int32_t,uint8_t *);
 void tsethlineshift(int32_t,int32_t);
-void setupslopevlin(int32_t,int32_t,int32_t);
-void slopevlin(int32_t,uint32_t,int32_t,int32_t,int32_t,int32_t);
+void setupslopevlin(int32_t,intptr_t,int32_t);
+void slopevlin(intptr_t,uint32_t,int32_t,int32_t,int32_t,int32_t);
     
     
 #define TRANS_NORMAL  0

--- a/Engine/src/engine.c
+++ b/Engine/src/engine.c
@@ -190,8 +190,8 @@ uint8_t  globparaceilclip, globparaflorclip;
 
 int32_t xyaspect, viewingrangerecip;
 
-int32_t asm1, asm2, asm4;
-intptr_t asm3;
+int32_t asm1, asm4;
+intptr_t asm2, asm3;
 
 
 int32_t vplce[4], vince[4];
@@ -3047,8 +3047,8 @@ static int spritewallfront (spritetype *s, int32_t w)
 
 static void transmaskvline(int32_t x)
 {
-    int32_t vplc, vinc, p, i, palookupoffs;
-    intptr_t bufplc;
+    int32_t vplc, vinc, i, palookupoffs;
+    intptr_t bufplc, p;
     short y1v, y2v;
 
     if ((x < 0) || (x >= xdimen)) return;
@@ -3079,7 +3079,8 @@ static void transmaskvline(int32_t x)
 
 static void transmaskvline2 (int32_t x)
 {
-    int32_t i, y1, y2, x2;
+    int32_t y1, y2, x2;
+    intptr_t i;
     short y1ve[2], y2ve[2];
 
     if ((x < 0) || (x >= xdimen)) return;

--- a/Engine/src/engine.c
+++ b/Engine/src/engine.c
@@ -190,11 +190,12 @@ uint8_t  globparaceilclip, globparaflorclip;
 
 int32_t xyaspect, viewingrangerecip;
 
-int32_t asm1, asm2, asm3, asm4;
+int32_t asm1, asm2, asm4;
+intptr_t asm3;
 
 
 int32_t vplce[4], vince[4];
-int32_t bufplce[4];
+intptr_t bufplce[4];
 
 uint8_t*  palookupoffse[4];
 
@@ -1224,7 +1225,8 @@ static void wallscan(int32_t x1, int32_t x2,
                      int16_t *uwal, int16_t *dwal,
                      int32_t *swal, int32_t *lwal)
 {
-    int32_t i, x, xnice, ynice;
+    int32_t x, xnice, ynice;
+    intptr_t i;
     uint8_t* fpalookup;
     int32_t y1ve[4], y2ve[4], u4, d4, z, tileWidth, tsizy;
     uint8_t  bad;
@@ -1413,7 +1415,8 @@ static void maskwallscan(int32_t x1, int32_t x2,
                          short *uwal, short *dwal,
                          int32_t *swal, int32_t *lwal)
 {
-    int32_t i, x, startx, xnice, ynice;
+    int32_t x, startx, xnice, ynice;
+    intptr_t i;
     uint8_t* fpalookup;
     int32_t y1ve[4], y2ve[4], u4, d4, dax, z, tileWidth, tileHeight;
     uint8_t*  p;
@@ -3044,7 +3047,8 @@ static int spritewallfront (spritetype *s, int32_t w)
 
 static void transmaskvline(int32_t x)
 {
-    int32_t vplc, vinc, p, i, palookupoffs, bufplc;
+    int32_t vplc, vinc, p, i, palookupoffs;
+    intptr_t bufplc;
     short y1v, y2v;
 
     if ((x < 0) || (x >= xdimen)) return;

--- a/Engine/src/engine.c
+++ b/Engine/src/engine.c
@@ -9105,7 +9105,8 @@ void preparemirror(int32_t dax, int32_t day, int32_t daz,
 
 void completemirror(void)
 {
-    int32_t i, dy, p;
+    int32_t i, dy;
+    intptr_t p;
 
     /* Can't reverse with uninitialized data */
     if (inpreparemirror) {

--- a/Engine/src/filesystem.c
+++ b/Engine/src/filesystem.c
@@ -473,8 +473,8 @@ int32_t compress(uint8_t  *lzwinbuf, int32_t uncompleng, uint8_t  *lzwoutbuf)
 	short *shortptr;
     
 	for(i=255;i>=0;i--) { lzwbuf1[i] = (uint8_t ) i; lzwbuf3[i] = (short) ((i+1)&255); }
-	clearbuf((void *) FP_OFF(lzwbuf2),256>>1,0xffffffff);
-	clearbuf((void *) FP_OFF(lzwoutbuf),((uncompleng+15)+3)>>2,0L);
+	clearbuf((void *) (lzwbuf2),256>>1,0xffffffff);
+	clearbuf((void *) (lzwoutbuf),((uncompleng+15)+3)>>2,0L);
     
 	addrcnt = 256; bytecnt1 = 0; bitcnt = (4<<3);
 	numbits = 8; oneupnumbits = (1<<8);
@@ -538,7 +538,7 @@ int32_t uncompress(uint8_t  *lzwinbuf, int32_t compleng, uint8_t  *lzwoutbuf)
 	strtot = (int32_t )shortptr[1];
 	if (strtot == 0)
 	{
-		copybuf((void *)(FP_OFF(lzwinbuf)+4),(void *)(FP_OFF(lzwoutbuf)),((compleng-4)+3)>>2);
+		copybuf((void *)((lzwinbuf)+4),(void *)((lzwoutbuf)),((compleng-4)+3)>>2);
 		return((int32_t )shortptr[0]); /* uncompleng */
 	}
 	for(i=255;i>=0;i--) { lzwbuf2[i] = (short) i; lzwbuf3[i] = (short) i; }

--- a/Game/src/audiolib/_multivc.h
+++ b/Game/src/audiolib/_multivc.h
@@ -113,7 +113,7 @@ typedef struct VoiceNode
 
    uint8_t       *sound;
    unsigned long length;
-   unsigned long SamplingRate;
+   uint32_t SamplingRate;
    unsigned long RateScale;
    unsigned long position;
    int           Playing;

--- a/Game/src/sector.c
+++ b/Game/src/sector.c
@@ -2712,7 +2712,7 @@ void cheatkeys(short snum)
                     sb_snum |= 1<<19;
                     p->weapon_pos = -9;
                 }
-                else if( p->gotweapon[j] && p->curr_weapon != j ) switch(j)
+                else if(j < MAX_WEAPONS && p->gotweapon[j] && p->curr_weapon != j ) switch(j)
                 {
                     case KNEE_WEAPON:
                         addweapon( p, KNEE_WEAPON );


### PR DESCRIPTION
With these changes, I was able to complete L.A. Meltdown on 64-bit Arch Linux. Ubuntu and Antergos 64-bit Linux were also tested.

2 known issues:
1. The ending cutscenes after an episode black out after some time.
2. On my Arch Linux machine, certain sounds (like BAR_MUSIC in E1M2) play too fast.

I have no idea if these fixes work on Windows or Mac 64-bit compiles.
