### PR TITLE
Avoid ambiguous types.h includes, remove redundant build.h include

### DIFF
--- a/Engine/src/cache.c
+++ b/Engine/src/cache.c
@@ -22,7 +22,7 @@
 
 #include "../../Game/src/cvar_defs.h"
 
-#include "types.h"
+#include "../../Game/src/types.h"
 
 /*
  *   This module keeps track of a standard linear cacheing system.

--- a/Game/src/cvar_defs.c
+++ b/Game/src/cvar_defs.c
@@ -5,7 +5,7 @@
 #include "console.h"
 
 // Required for certain cvars
-#include "types.h"
+#include "../../Game/src/types.h"
 #include "build.h"
 #include "funct.h"
 

--- a/Game/src/duke3d.h
+++ b/Game/src/duke3d.h
@@ -84,7 +84,6 @@ Prepared for public release: 03/21/2003 - Charlie Wiederhold, 3D Realms
 #include "SDL_mixer.h"
 #endif
 
-#include "build.h"
 #include "function.h"
 
 //  FIX_00022: Automatically recognize the shareware grp (v1.3) + full version (1.3d) +
@@ -159,7 +158,7 @@ extern int BYTEVERSION_1_3;
 
 struct player_struct;
 
-#include "types.h"
+#include "../../Game/src/types.h"
 #include "file_lib.h"
 #include "develop.h"
 #include "gamedefs.h"

--- a/Game/src/sounds.c
+++ b/Game/src/sounds.c
@@ -30,7 +30,7 @@ Prepared for public release: 03/21/2003 - Charlie Wiederhold, 3D Realms
 
 #include <stdio.h>
 #include <string.h>
-#include "types.h"
+#include "../../Game/src/types.h"
 #include "util_lib.h"
 #include "duke3d.h"
 #include "global.h"


### PR DESCRIPTION
There are way too many types.h files among my system headers that might conflict here.