### PR TITLE
Fix door animation.

### DIFF
--- a/Game/src/sector.c
+++ b/Game/src/sector.c
@@ -849,13 +849,13 @@ void operatesectors(short sn,short ii)
             if ( (sptr->lotag&0x8000) )
             {
                 q = (sptr->ceilingz+sptr->floorz)>>1;
-               // j = setanimation(sn,&sptr->floorz,q,sptr->extra);
+                j = setanimation(sn,&sptr->floorz,q,sptr->extra);
                 j = setanimation(sn,&sptr->ceilingz,q,sptr->extra);
             }
             else
             {
                 q = sector[nextsectorneighborz(sn,sptr->floorz,1,1)].floorz;
-               // j = setanimation(sn,&sptr->floorz,q,sptr->extra);
+                j = setanimation(sn,&sptr->floorz,q,sptr->extra);
                 q = sector[nextsectorneighborz(sn,sptr->ceilingz,-1,-1)].ceilingz;
                 j = setanimation(sn,&sptr->ceilingz,q,sptr->extra);
             }


### PR DESCRIPTION
This is a critical fix. Currently, the player cannot go through the third door (in the Assault Enforcer hallway) of E2M5 as it does not fully open.

The change that broke the door behavior is here:
https://github.com/fabiensanglard/chocolate_duke3D/commit/a7d509eca0ad2ece012d0fc46f73bdbf65695ac2