### PR TITLE
Fix some floors being drawn too dark.

### DIFF
--- a/Engine/src/engine.c
+++ b/Engine/src/engine.c
@@ -987,7 +987,7 @@ static void florscan (int32_t x1, int32_t x2, int32_t sectnum)
     
     globvis = globalcisibility;
     if (sec->visibility != 0)
-        globvis = mulscale4(globvis,(int32_t)((sec->visibility+16)));
+        globvis = mulscale4(globvis,(int32_t)((uint8_t)(sec->visibility+16)));
     
     
     globalorientation = (int32_t)sec->floorstat;


### PR DESCRIPTION
I noticed this issue mostly at the beginning of E3M1, where the shadowed floors at the top and near of the starting building at the bottom are almost solid black.

That change that caused this behavior is here:
e9379d17f01bce87e474f57cab1dee6e0d9b03f9