### PR TITLE
Ensure X axis mouse aim works while strafing.

### DIFF
--- a/Game/src/player.c
+++ b/Game/src/player.c
@@ -2069,10 +2069,16 @@ void getinput(short snum)
     }
 
     if ( ACTION( gamefunc_Strafe_Left ) )
+        {
         svel += keymove;
+        angvel = (info.dyaw+previousInfoDyaw)/64;
+        }
 
     if ( ACTION( gamefunc_Strafe_Right ) )
+        {
         svel += -keymove;
+        angvel = (info.dyaw+previousInfoDyaw)/64;
+        }
 
     if ( ACTION(gamefunc_Move_Forward) )
         vel += keymove;


### PR DESCRIPTION
After customizing the controls to be more like a modern shooter (enable mouse aiming, set WASD keyboard shortcuts) I noticed horizontal mouse aim does not work while holding down a strafe. 